### PR TITLE
Encode seq before sending request

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -154,7 +154,7 @@ get_pending_count(#httpdb{} = Db, Seq) when is_number(Seq) ->
         end
     end);
 get_pending_count(#httpdb{} = Db, Seq) ->
-    Options = [{path, "_changes"}, {qs, [{"since", Seq}, {"limit", "0"}]}],
+    Options = [{path, "_changes"}, {qs, [{"since", ?JSON_ENCODE(Seq)}, {"limit", "0"}]}],
     send_req(Db, Options, fun(200, _, {Props}) ->
         {ok, couch_util:get_value(<<"pending">>, Props, null)}
     end);


### PR DESCRIPTION
CouchDB 2.0 sequences are lists (of form [non_neg_integer(),
binary()]) where previously they were strings (either as binary or as
list) or numbers. The replicator calls iolist_to_binary on all
parameters which scrambles this new format.

Ensure we've JSON encoded the since value to a binary before calling send_req.
