### PR TITLE
abort_multi_part_stream has been moved and renamed into couch_httpd_mutl...

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -674,7 +674,7 @@ receive_docs(Streamer, UserFun, Ref, UserAcc) ->
                 {ok, UserAcc2} ->
                     ok;
                 {skip, UserAcc2} ->
-                    couch_doc:abort_multi_part_stream(Parser)
+                    couch_httpd_multipart:abort_multi_part_stream(Parser)
                 end,
                 WaitFun(),
                 receive_docs(Streamer, UserFun, Ref, UserAcc2)


### PR DESCRIPTION
...ipart:abort_multipart_stream