### PR TITLE
Return context from test_util:start_couch

### DIFF
--- a/test/couch_replicator_compact_tests.erl
+++ b/test/couch_replicator_compact_tests.erl
@@ -34,10 +34,10 @@ setup(local) ->
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
-    ok = test_util:start_couch([couch_replicator]),
+    Ctx = test_util:start_couch([couch_replicator]),
     Source = setup(A),
     Target = setup(B),
-    {Source, Target}.
+    {Ctx, {Source, Target}}.
 
 teardown({remote, DbName}) ->
     teardown(DbName);
@@ -45,11 +45,11 @@ teardown(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
-teardown(_, {Source, Target}) ->
+teardown(_, {Ctx, {Source, Target}}) ->
     teardown(Source),
     teardown(Target),
     ok = application:stop(couch_replicator),
-    ok = test_util:stop_couch().
+    ok = test_util:stop_couch(Ctx).
 
 compact_test_() ->
     Pairs = [{local, local}, {local, remote},
@@ -65,7 +65,7 @@ compact_test_() ->
     }.
 
 
-should_populate_replicate_compact({From, To}, {Source, Target}) ->
+should_populate_replicate_compact({From, To}, {_Ctx, {Source, Target}}) ->
     {ok, RepPid, RepId} = replicate(Source, Target),
     {lists:flatten(io_lib:format("~p -> ~p", [From, To])),
      {inorder, [

--- a/test/couch_replicator_large_atts_tests.erl
+++ b/test/couch_replicator_large_atts_tests.erl
@@ -39,11 +39,11 @@ setup(local) ->
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
-    ok = test_util:start_couch([couch_replicator]),
+    Ctx = test_util:start_couch([couch_replicator]),
     config:set("attachments", "compressible_types", "text/*", false),
     Source = setup(A),
     Target = setup(B),
-    {Source, Target}.
+    {Ctx, {Source, Target}}.
 
 teardown({remote, DbName}) ->
     teardown(DbName);
@@ -51,12 +51,12 @@ teardown(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
-teardown(_, {Source, Target}) ->
+teardown(_, {Ctx, {Source, Target}}) ->
     teardown(Source),
     teardown(Target),
 
     ok = application:stop(couch_replicator),
-    ok = test_util:stop_couch().
+    ok = test_util:stop_couch(Ctx).
 
 large_atts_test_() ->
     Pairs = [{local, local}, {local, remote},
@@ -72,7 +72,7 @@ large_atts_test_() ->
     }.
 
 
-should_populate_replicate_compact({From, To}, {Source, Target}) ->
+should_populate_replicate_compact({From, To}, {_Ctx, {Source, Target}}) ->
     {lists:flatten(io_lib:format("~p -> ~p", [From, To])),
      {inorder, [should_populate_source(Source),
                 should_replicate(Source, Target),

--- a/test/couch_replicator_many_leaves_tests.erl
+++ b/test/couch_replicator_many_leaves_tests.erl
@@ -38,10 +38,10 @@ setup(local) ->
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
-    ok = test_util:start_couch([couch_replicator]),
+    Ctx = test_util:start_couch([couch_replicator]),
     Source = setup(A),
     Target = setup(B),
-    {Source, Target}.
+    {Ctx, {Source, Target}}.
 
 teardown({remote, DbName}) ->
     teardown(DbName);
@@ -49,11 +49,11 @@ teardown(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
-teardown(_, {Source, Target}) ->
+teardown(_, {Ctx, {Source, Target}}) ->
     teardown(Source),
     teardown(Target),
     ok = application:stop(couch_replicator),
-    ok = test_util:stop_couch().
+    ok = test_util:stop_couch(Ctx).
 
 docs_with_many_leaves_test_() ->
     Pairs = [{local, local}, {local, remote},
@@ -69,7 +69,7 @@ docs_with_many_leaves_test_() ->
     }.
 
 
-should_populate_replicate_compact({From, To}, {Source, Target}) ->
+should_populate_replicate_compact({From, To}, {_Ctx, {Source, Target}}) ->
     {lists:flatten(io_lib:format("~p -> ~p", [From, To])),
      {inorder, [
         should_populate_source(Source),

--- a/test/couch_replicator_missing_stubs_tests.erl
+++ b/test/couch_replicator_missing_stubs_tests.erl
@@ -36,10 +36,10 @@ setup(local) ->
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
-    ok = test_util:start_couch([couch_replicator]),
+    Ctx = test_util:start_couch([couch_replicator]),
     Source = setup(A),
     Target = setup(B),
-    {Source, Target}.
+    {Ctx, {Source, Target}}.
 
 teardown({remote, DbName}) ->
     teardown(DbName);
@@ -47,11 +47,11 @@ teardown(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
-teardown(_, {Source, Target}) ->
+teardown(_, {Ctx, {Source, Target}}) ->
     teardown(Source),
     teardown(Target),
     ok = application:stop(couch_replicator),
-    ok = test_util:stop_couch().
+    ok = test_util:stop_couch(Ctx).
 
 missing_stubs_test_() ->
     Pairs = [{local, local}, {local, remote},
@@ -67,7 +67,7 @@ missing_stubs_test_() ->
     }.
 
 
-should_replicate_docs_with_missed_att_stubs({From, To}, {Source, Target}) ->
+should_replicate_docs_with_missed_att_stubs({From, To}, {_Ctx, {Source, Target}}) ->
     {lists:flatten(io_lib:format("~p -> ~p", [From, To])),
      {inorder, [
         should_populate_source(Source),

--- a/test/couch_replicator_use_checkpoints_tests.erl
+++ b/test/couch_replicator_use_checkpoints_tests.erl
@@ -52,11 +52,11 @@ setup(local) ->
 setup(remote) ->
     {remote, setup()};
 setup({_, Fun, {A, B}}) ->
-    ok = test_util:start_couch([couch_replicator]),
+    Ctx = test_util:start_couch([couch_replicator]),
     {ok, Listener} = couch_replicator_notifier:start_link(Fun),
     Source = setup(A),
     Target = setup(B),
-    {Source, Target, Listener}.
+    {Ctx, {Source, Target, Listener}}.
 
 teardown({remote, DbName}) ->
     teardown(DbName);
@@ -64,13 +64,13 @@ teardown(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
-teardown(_, {Source, Target, Listener}) ->
+teardown(_, {Ctx, {Source, Target, Listener}}) ->
     teardown(Source),
     teardown(Target),
 
     couch_replicator_notifier:stop(Listener),
     ok = application:stop(couch_replicator),
-    ok = test_util:stop_couch().
+    ok = test_util:stop_couch(Ctx).
 
 use_checkpoints_test_() ->
     {
@@ -96,7 +96,7 @@ use_checkpoints_tests(UseCheckpoints, Fun) ->
         }
     }.
 
-should_test_checkpoints({UseCheckpoints, _, {From, To}}, {Source, Target, _}) ->
+should_test_checkpoints({UseCheckpoints, _, {From, To}}, {_Ctx, {Source, Target, _}}) ->
     should_test_checkpoints(UseCheckpoints, {From, To}, {Source, Target}).
 should_test_checkpoints(UseCheckpoints, {From, To}, {Source, Target}) ->
     {lists:flatten(io_lib:format("~p -> ~p", [From, To])),


### PR DESCRIPTION
We are going to return some context from start_couch so we pass it
around

COUCHDB-2547