### PR TITLE
2707 merge couch replicator fixes from cloudant fork

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -475,13 +475,20 @@ handle_cast({db_compacted, DbName},
     {noreply, State#rep_state{target = NewTarget}};
 
 handle_cast(checkpoint, State) ->
-    case do_checkpoint(State) of
-    {ok, NewState} ->
-        couch_stats:increment_counter([couch_replicator, checkpoints, success]),
-        {noreply, NewState#rep_state{timer = start_timer(State)}};
-    Error ->
-        couch_stats:increment_counter([couch_replicator, checkpoints, failure]),
-        {stop, Error, State}
+    #rep_state{rep_details = #rep{id = RepId} = Rep} = State,
+    case couch_replicator_manager:owner(RepId) of
+    Owner when Owner == node() ->
+        case do_checkpoint(State) of
+        {ok, NewState} ->
+            couch_stats:increment_counter([couch_replicator, checkpoints, success]),
+            {noreply, NewState#rep_state{timer = start_timer(State)}};
+        Error ->
+            couch_stats:increment_counter([couch_replicator, checkpoints, failure]),
+            {stop, Error, State}
+        end;
+    Owner ->
+        couch_replicator_manager:replication_usurped(Rep, Owner),
+        {stop, shutdown, State}
     end;
 
 handle_cast({report_seq, Seq},

--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -475,9 +475,9 @@ handle_cast({db_compacted, DbName},
     {noreply, State#rep_state{target = NewTarget}};
 
 handle_cast(checkpoint, State) ->
-    #rep_state{rep_details = #rep{id = RepId} = Rep} = State,
-    case couch_replicator_manager:owner(RepId) of
-    Owner when Owner == node() ->
+    #rep_state{rep_details = #rep{} = Rep} = State,
+    case couch_replicator_manager:continue(Rep) of
+    {true, _} ->
         case do_checkpoint(State) of
         {ok, NewState} ->
             couch_stats:increment_counter([couch_replicator, checkpoints, success]),
@@ -486,7 +486,7 @@ handle_cast(checkpoint, State) ->
             couch_stats:increment_counter([couch_replicator, checkpoints, failure]),
             {stop, Error, State}
         end;
-    Owner ->
+    {false, Owner} ->
         couch_replicator_manager:replication_usurped(Rep, Owner),
         {stop, shutdown, State}
     end;

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -179,6 +179,8 @@ clean_mailbox({ibrowse_req_id, ReqId}) ->
                 {ibrowse_async_response_end, ReqId} ->
                     put(?STREAM_STATUS, ended),
                     ok
+                after 30000 ->
+                    exit({timeout, ibrowse_stream_cleanup})
             end;
         Status when Status == init; Status == ended ->
             receive
@@ -186,6 +188,8 @@ clean_mailbox({ibrowse_req_id, ReqId}) ->
                     clean_mailbox({ibrowse_req_id, ReqId});
                 {ibrowse_async_response_end, ReqId} ->
                     put(?STREAM_STATUS, ended),
+                    ok
+                after 0 ->
                     ok
             end
     end;

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -237,10 +237,12 @@ handle_cast(Msg, State) ->
     {stop, {error, {unexpected_cast, Msg}}, State}.
 
 handle_info({nodeup, Node}, State) ->
+    couch_log:notice("Rescanning replicator dbs as ~s came up.", [Node]),
     Live = lists:usort([Node | State#state.live]),
     {noreply, rescan(State#state{live=Live})};
 
 handle_info({nodedown, Node}, State) ->
+    couch_log:notice("Rescanning replicator dbs ~s went down.", [Node]),
     Live = State#state.live -- [Node],
     {noreply, rescan(State#state{live=Live})};
 

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -17,7 +17,7 @@
 
 % public API
 -export([replication_started/1, replication_completed/2, replication_error/2]).
--export([owner/1]).
+-export([owner/1, replication_usurped/2]).
 
 -export([before_doc_update/2, after_doc_read/2]).
 
@@ -105,6 +105,17 @@ replication_completed(#rep{id = RepId}, Stats) ->
         ok = gen_server:call(?MODULE, {rep_complete, RepId}, infinity),
         couch_log:notice("Replication `~s` finished (triggered by document `~s`)",
             [pp_rep_id(RepId), DocId])
+    end.
+
+
+replication_usurped(#rep{id = RepId}, By) ->
+    case rep_state(RepId) of
+    nil ->
+        ok;
+    #rep_state{rep = #rep{doc_id = DocId}} ->
+        ok = gen_server:call(?MODULE, {rep_complete, RepId}, infinity),
+        couch_log:notice("Replication `~s` usurped by ~s (triggered by document `~s`)",
+            [pp_rep_id(RepId), By, DocId])
     end.
 
 

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -134,7 +134,7 @@ replication_error(#rep{id = {BaseId, _} = RepId}, Error) ->
 continue(#rep{doc_id = null}) ->
     {true, no_owner};
 continue(#rep{id = RepId}) ->
-    Owner = gen_server:call(?MODULE, {owner, RepId}),
+    Owner = gen_server:call(?MODULE, {owner, RepId}, infinity),
     {node() == Owner, Owner}.
 
 


### PR DESCRIPTION
This PR brings in a number of fixes for couch_replicator from the Cloudant fork at https://github.com/cloudant/couch_replicator

Closes COUCHDB-2707.
