### PR TITLE
Return `{error, {illegal_database_name, Name}}`

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -124,7 +124,7 @@ db_open(DbName, Options, Create) ->
             couch_db:create(DbName, Options)
         end,
         case couch_db:open(DbName, Options) of
-        {error, illegal_database_name, _} ->
+        {error, {illegal_database_name, _}} ->
             throw({db_not_found, DbName});
         {not_found, _Reason} ->
             throw({db_not_found, DbName});


### PR DESCRIPTION
This is one of the series of PRs to make couchdb plugable. I'll provide complete list of dependent PRs in https://github.com/apache/couchdb-couch repository.