### PR TITLE
Include originating database

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -295,6 +295,7 @@ do_init(#rep{options = Options, id = {BaseId, Ext}, user_ctx=UserCtx} = Rep) ->
         {type, replication},
         {user, UserCtx#user_ctx.name},
         {replication_id, ?l2b(BaseId ++ Ext)},
+        {database, Rep#rep.db_name},
         {doc_id, Rep#rep.doc_id},
         {source, ?l2b(SourceName)},
         {target, ?l2b(TargetName)},

--- a/src/couch_replicator.hrl
+++ b/src/couch_replicator.hrl
@@ -20,5 +20,6 @@
     user_ctx,
     type = db,
     view = nil,
-    doc_id
+    doc_id,
+    db_name = null
 }).


### PR DESCRIPTION
Any database whose path ends in /_replicator is considered a
replicator database. Show this name in the active tasks output so that
the doc_id can be easily found in all cases.