### PR TITLE
Fix race condition in waiting for compactor in eunit test.

### DIFF
--- a/test/couch_replicator_compact_tests.erl
+++ b/test/couch_replicator_compact_tests.erl
@@ -263,6 +263,8 @@ compact_db(Type, #db{name = Name}) ->
     receive
         {'DOWN', MonRef, process, CompactPid, normal} ->
             ok;
+        {'DOWN', MonRef, process, CompactPid, noproc} ->
+            ok;
         {'DOWN', MonRef, process, CompactPid, Reason} ->
             erlang:error(
                 {assertion_failed,
@@ -284,11 +286,13 @@ wait_for_compaction(Type, Db) ->
     case couch_db:wait_for_compaction(Db) of
         ok ->
             ok;
+        {error, noproc} ->
+            ok;
         {error, Reason} ->
             erlang:error(
                 {assertion_failed,
                  [{module, ?MODULE}, {line, ?LINE},
-                  {reason, lists:concat(["Compaction of", Type,
+                  {reason, lists:concat(["Compaction of ", Type,
                                          " database failed with: ", Reason])}]})
     end.
 


### PR DESCRIPTION
Monitor waiting for replicator will sometimes fail with noproc
error, because there is a race condition between a running
compactor process and setting up its monitor and waiting on it.

This error appears about once or twice in a 100 runs.
It can be made to appear more often by tweaking 50 and 5 values in:
```
 should_populate_and_compact(RepPid, Source, Target, 50, 5),
```
to something like 1, 20.

This commit fixes race condition by handling noproc.