### PR TITLE
Fix view filtered replication

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -642,15 +642,7 @@ init_state(Rep) ->
     StartSeq1 = get_value(since_seq, Options, StartSeq0),
     StartSeq = {0, StartSeq1},
 
-    SourceSeq = case Type of
-        db -> get_value(<<"update_seq">>, SourceInfo, ?LOWEST_SEQ);
-        view ->
-            {DDoc, VName} = View,
-            {ok, VInfo} = couch_replicator_api_wrap:get_view_info(Source, DDoc,
-                                                                  VName),
-            get_value(<<"update_seq">>, VInfo, ?LOWEST_SEQ)
-    end,
-
+    SourceSeq = get_value(<<"update_seq">>, SourceInfo, ?LOWEST_SEQ),
 
     #doc{body={CheckpointHistory}} = SourceLog,
     State = #rep_state{

--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -178,13 +178,15 @@ get_pending_count(#db{name=DbName}=Db, Seq) when is_number(Seq) ->
     {ok, Pending}.
 
 get_view_info(#httpdb{} = Db, DDocId, ViewName) ->
-    Path = iolist_to_binary([DDocId, "/_view/", ViewName, "/_info"]),
+    Path = io_lib:format("~s/_view/~s/_info", [DDocId, ViewName]),
     send_req(Db, [{path, Path}],
         fun(200, _, {Props}) ->
-            {ok, Props}
+            {VInfo} = couch_util:get_value(<<"view_index">>, Props, {[]}),
+            {ok, VInfo}
         end);
 get_view_info(#db{name = DbName}, DDocId, ViewName) ->
-    couch_mrview:get_view_info(DbName, DDocId, ViewName).
+    {ok, VInfo} = couch_mrview:get_view_info(DbName, DDocId, ViewName),
+    {ok, [{couch_util:to_binary(K), V} || {K, V} <- VInfo]}.
 
 
 ensure_full_commit(#httpdb{} = Db) ->


### PR DESCRIPTION
This fixes the filtered by view replication for the views built without seq_indexed option.

I kept `couch_replicator_api_wrap:get_view_info/3` function for a back reference even though we can't use it right now in the clustered environment as it's not marshalled through fabric. 