### PR TITLE
Do not crash in couch_replicator:terminate/2 if a local dbname is used.

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -519,7 +519,9 @@ httpdb_strip_creds(#httpdb{url = Url, headers = Headers} = HttpDb) ->
     HttpDb#httpdb{
         url = couch_util:url_strip_password(Url),
         headers = headers_strip_creds(Headers, [])
-    }.
+    };
+httpdb_strip_creds(LocalDb) ->
+    LocalDb.
 
 
 rep_strip_creds(#rep{source = Source, target = Target} = Rep) ->


### PR DESCRIPTION
Even though local source or target database names are not valid
for replication in CouchDB 2.0, do not crash when trying to
strip credentials. Replicator process has to terminate properly
in order to report the error in the replication document for
user feedback.

JIRA: COUCHDB-2949