### PR TITLE
Switch replicator manager change feeds to "longpoll"

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -354,7 +354,7 @@ changes_reader(Server, DbName, Since) ->
         #changes_args{
             include_docs = true,
             since = Since,
-            feed = "continuous",
+            feed = "longpoll",
             timeout = infinity
         },
         {json_req, null},


### PR DESCRIPTION
Fixes replication manager rescans on cluster membership
change.

Replication manager resets all replication db
sequence checkpoints, and starts a new replicator db
background scanner.  Each replicator database is signaled
to rescan from sequence 0. However previous change feeds
for each db have to exit first. If they never exit, because
they are "continuous" new change feeds will never start.

Putting change feeds in "longpoll" mode ensures they will
eventually exit.

JIRA: COUCHDB-2963