### PR TITLE
Fix flaky replicator tests.

### DIFF
--- a/test/couch_replicator_compact_tests.erl
+++ b/test/couch_replicator_compact_tests.erl
@@ -19,8 +19,7 @@
 -define(ATTFILE, filename:join([?FIXTURESDIR, "logo.png"])).
 -define(DELAY, 100).
 -define(TIMEOUT, 30000).
--define(TIMEOUT_STOP, 1000).
--define(TIMEOUT_WRITER, 3000).
+-define(TIMEOUT_WRITER, 9000).
 -define(TIMEOUT_EUNIT, ?TIMEOUT div 1000 + 70).
 
 setup() ->

--- a/test/couch_replicator_large_atts_tests.erl
+++ b/test/couch_replicator_large_atts_tests.erl
@@ -25,7 +25,6 @@
 -define(ATT_SIZE_2, round(6.6 * 1024 * 1024)).
 -define(DOCS_COUNT, 11).
 -define(TIMEOUT_EUNIT, 30).
--define(TIMEOUT_STOP, 1000).
 
 
 setup() ->

--- a/test/couch_replicator_many_leaves_tests.erl
+++ b/test/couch_replicator_many_leaves_tests.erl
@@ -22,7 +22,6 @@
     {<<"doc3">>, 210}
 ]).
 -define(NUM_ATTS, 2).
--define(TIMEOUT_STOP, 1000).
 -define(TIMEOUT_EUNIT, 60).
 -define(i2l(I), integer_to_list(I)).
 -define(io2b(Io), iolist_to_binary(Io)).

--- a/test/couch_replicator_missing_stubs_tests.erl
+++ b/test/couch_replicator_missing_stubs_tests.erl
@@ -22,7 +22,6 @@
 ]).
 
 -define(REVS_LIMIT, 3).
--define(TIMEOUT_STOP, 1000).
 -define(TIMEOUT_EUNIT, 30).
 
 setup() ->

--- a/test/couch_replicator_use_checkpoints_tests.erl
+++ b/test/couch_replicator_use_checkpoints_tests.erl
@@ -16,7 +16,6 @@
 -include_lib("couch/include/couch_db.hrl").
 
 -define(DOCS_COUNT, 100).
--define(TIMEOUT_STOP, 1000).
 -define(TIMEOUT_EUNIT, 30).
 -define(i2l(I), integer_to_list(I)).
 -define(io2b(Io), iolist_to_binary(Io)).


### PR DESCRIPTION
Replication+compaction test periodically times out
when running under CI. Adjust writer timeout from 3 to 9 sec.

Also clean up confusing / unused TIMEOUT_STOP constant.