### PR TITLE
Use couch_db:dbname_suffix in is_replicator_db

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -922,12 +922,7 @@ scan_all_dbs(Server) when is_pid(Server) ->
 	end, ok).
 
 is_replicator_db(DbName) ->
-    case lists:last(binary:split(mem3:dbname(DbName), <<"/">>, [global])) of
-        <<"_replicator">> ->
-            true;
-        _ ->
-            false
-    end.
+    <<"_replicator">> =:= couch_db:dbname_suffix(DbName).
 
 get_json_value(Key, Props) ->
     get_json_value(Key, Props, undefined).


### PR DESCRIPTION
couch_db:dbname_suffix would take shard's suffix into account.

This PR depends on https://github.com/apache/couchdb-couch/pull/160

COUCHDB-2983