### PR TITLE
Add New Rate Limiter For Replication

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -136,9 +136,11 @@ db_open(DbName, Options, Create) ->
         throw({unauthorized, DbName})
     end.
 
-db_close(#httpdb{httpc_pool = Pool}) ->
+db_close(#httpdb{httpc_pool = Pool, url = Url}) ->
     unlink(Pool),
-    ok = couch_replicator_httpc_pool:stop(Pool);
+    ok = couch_replicator_httpc_pool:stop(Pool),
+    couch_replicator_rate_limiter:maybe_decrement_rep_count(Url),
+    ok;
 db_close(DbName) ->
     catch couch_db:close(DbName).
 

--- a/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator_httpc_pool.erl
@@ -23,6 +23,7 @@
 -export([code_change/3, terminate/2]).
 
 -include_lib("couch/include/couch_db.hrl").
+-include_lib("ibrowse/include/ibrowse.hrl").
 
 -import(couch_util, [
     get_value/2

--- a/src/couch_replicator_rate_limiter.erl
+++ b/src/couch_replicator_rate_limiter.erl
@@ -1,0 +1,219 @@
+-module(couch_replicator_rate_limiter).
+-behaviour(gen_server).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("ibrowse/include/ibrowse.hrl").
+-include_lib("couch_replicator_api_wrap.hrl").
+
+
+-export([
+    start_link/0
+]).
+
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3
+]).
+
+-export ([
+    maybe_start_rate_limiter/3,
+    maybe_decrement_rep_count/1,
+    maybe_delay_request/1
+    ]).
+
+-record(rep_limiter, {
+    requestCounter = 0,
+    lastUpdateTimestamp = 0,
+    pid,
+    replications = 0,
+    limit, % max requests
+    period % interval is in seconds
+}).
+
+
+%% For each unique host, an entry is a rep_limiter record
+-define(HOSTS, couch_replicator_limit_hosts).
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+update_host(Host, Limit, Period) ->
+    gen_server:call(?MODULE, {update_host, Host, Limit, Period}, infinity).
+
+
+decrement_replications(Host) ->
+    gen_server:call(?MODULE, {decrement_replications, Host}, infinity).
+
+
+% gen_server functions.
+init([]) ->
+    process_flag(trap_exit, true),
+    ets:new(?HOSTS, [set, public, named_table]),
+    {ok, nil}.
+
+
+handle_call({update_host, Host, Limit, Period}, _From, State) ->
+    Reps = case ets:insert_new(?HOSTS, {Host, #rep_limiter{}}) of
+        true ->
+            % Brand new host for replication, need to spawn
+            % a new resetter process and initialize
+            LoopPid = spawn_link(fun() ->
+                reset_requests_loop(Host, Period)
+            end),
+            modify_host(Host, [{4, LoopPid}, {5, 1}, {6, Limit},
+                {7, Period}]),
+            1;
+        false ->
+            % this allows the rate limit to be changed during replication
+            modify_host(Host, [{6, Limit}, {7, Period}]),
+            update_rep_count(Host, 1)
+    end,
+    {ok, Reps, State};
+
+
+handle_call({decrement_replications, Host}, _From, State) ->
+    Replications = case update_rep_count(Host, -1) of
+        Rep0 when Rep0 =< 0 ->
+            ResetPid = ets:lookup_element(?HOSTS, Host, 4),
+            % no more replications at this moment, stop resetter
+            % process and remove the host from the ets table
+            exit(ResetPid, stop_resetter),
+            remove_host(Host);
+        _ ->
+            ok % this shoulld be some error
+    end,
+    {ok, Replications, State}.
+
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+
+handle_info({'EXIT', _FromPid, stop_resetter}, State) ->
+    {noreply, State};
+
+handle_info({'EXIT', _FromPid, Reason}, State) ->
+    couch_log:error("couch_replicator_rate_limiter reset process
+            died abnormally due to: ~p", [Reason]),
+    {noreply, State}.
+
+
+terminate(_Reason, _State) ->
+    ok.
+
+
+modify_host(Host, Elements) ->
+    ets:update_element(?HOSTS, Host, Elements).
+
+
+remove_host(Host) ->
+    ets:delete(?HOSTS, Host).
+
+
+update_rep_count(Host, Value) ->
+    ets:update_counter(?HOSTS, Host, {5, Value}).
+
+
+increment_req_count(Host) ->
+    ets:update_counter(?HOSTS, Host, {2, 1}).
+
+
+code_change(_OldVsn, nil, _Extra) ->
+    {ok, nil}.
+
+reset_requests_loop(Host, Period) ->
+    modify_host(Host, [{2, 0}, {3, os:timestamp()}]),
+    timer:sleep(Period),
+    reset_requests_loop(Host, Period).
+
+% Returns sleep time in milliseconds
+calculate_sleep_time(Host, RequestCounter) ->
+    {Limit, Period} = get_host_rate(Host),
+    Interval = (Period / Limit) * 1000,
+    LastUpdateTimestamp = ets:lookup_element(?HOSTS, Host, 3),
+    ReqTimestamp = os:timestamp(),
+    TimeDiff0 = timer:now_diff(ReqTimestamp, LastUpdateTimestamp),
+    TimeDiff1 = TimeDiff0 div 1000 rem 1000,
+    CountDiff = RequestCounter - Limit,
+    NextReset = ts_to_millisec(LastUpdateTimestamp) + (Period * 1000),
+    case {CountDiff, TimeDiff1} of
+        {C0, _} when C0 =< 0 ->
+            0;
+        {C0, T0} when T0 > 0 ->
+            (NextReset - T0) + (C0 * Interval);
+        {C0, T0} when T0 =< 0 ->
+             % This can occur if the request comes in really close to
+             % to the reset time and we read the reset value too late.
+             abs(T0) + (C0 * Interval)
+    end.
+
+
+ts_to_millisec({Mega, Sec, Micro}) ->
+    (Mega * 1000000) + (Sec * 1000) +  (Micro div 1000 rem 1000).
+
+
+get_host_rate(Host) ->
+    Limit =  try ets:lookup_element(?HOSTS, Host, 6) of
+        L ->
+            L
+        catch error:badarg ->
+            -1
+    end,
+    Period = try ets:lookup_element(?HOSTS, Host, 7) of
+        P ->
+            P
+        catch error:badarg ->
+            -1
+    end,
+    {Limit, Period}.
+
+
+
+maybe_start_rate_limiter(#httpdb{url = Url}, Limit, Period) ->
+    Host = ibrowse_lib:parse_url(Url),
+    case {Limit, Period} of
+        {-1, _} ->
+            false;
+        {_, -1} ->
+            false;
+        {L0, P0} ->
+            update_host(Host, L0, P0)
+    end;
+% disabled for local
+maybe_start_rate_limiter(_, _ , _) ->
+    false.
+
+
+maybe_decrement_rep_count(Url) ->
+    Host = ibrowse_lib:parse_url(Url),
+    {Limit, Period} = get_host_rate(Host),
+    case {Limit, Period} of
+        {-1, _} ->
+            false;
+        {_, -1} ->
+            false;
+        {_, _} ->
+            decrement_replications(Host)
+    end.
+
+
+maybe_delay_request(Url) ->
+    Host = ibrowse_lib:parse_url(Url),
+    {Limit, Period} = get_host_rate(Host),
+    case {Limit, Period} of
+        {-1, _} ->
+            false;
+        {_, -1} ->
+            false;
+        {_, _} ->
+            Counter = increment_req_count(Host),
+            Sleep = calculate_sleep_time(Host, Counter),
+            timer:sleep(Sleep)
+    end.

--- a/src/couch_replicator_sup.erl
+++ b/src/couch_replicator_sup.erl
@@ -32,6 +32,12 @@ init(_Args) ->
             brutal_kill,
             worker,
             [couch_replicator_manager]},
+        {couch_replicator_rate_limiter,
+            {couch_replicator_rate_limiter, start_link, []},
+            permanent,
+            brutal_kill, % Need to think about if this should be brutal_kill
+            worker,
+            [couch_replicator_rate_limiter]},
         {couch_replicator_job_sup,
             {couch_replicator_job_sup, start_link, []},
             permanent,

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -261,6 +261,10 @@ make_options(Props) ->
     DefRetries = config:get("replicator", "retries_per_request", "10"),
     UseCheckpoints = config:get("replicator", "use_checkpoints", "true"),
     DefCheckpointInterval = config:get("replicator", "checkpoint_interval", "30000"),
+    DefSrcLimit = config:get("replicator", "src_rate_limit", "-1"),
+    DefSrcPeriod = config:get("replicator", "src_rate_period", "-1"),
+    DefTrgLimit = config:get("replicator", "target_rate_limit", "-1"),
+    DefTrgPeriod = config:get("replicator", "target_rate_period", "-1"),
     {ok, DefSocketOptions} = couch_util:parse_term(
         config:get("replicator", "socket_options",
             "[{keepalive, true}, {nodelay, false}]")),
@@ -272,7 +276,11 @@ make_options(Props) ->
         {worker_batch_size, list_to_integer(DefBatchSize)},
         {worker_processes, list_to_integer(DefWorkers)},
         {use_checkpoints, list_to_existing_atom(UseCheckpoints)},
-        {checkpoint_interval, list_to_integer(DefCheckpointInterval)}
+        {checkpoint_interval, list_to_integer(DefCheckpointInterval)},
+        {src_rate_limit, list_to_integer(DefSrcLimit)},
+        {src_rate_period, list_to_integer(DefSrcPeriod)},
+        {target_rate_limit, list_to_integer(DefTrgLimit)},
+        {target_rate_period, list_to_integer(DefTrgPeriod)}
     ])).
 
 
@@ -324,6 +332,14 @@ convert_options([{<<"use_checkpoints">>, V} | R]) ->
     [{use_checkpoints, V} | convert_options(R)];
 convert_options([{<<"checkpoint_interval">>, V} | R]) ->
     [{checkpoint_interval, couch_util:to_integer(V)} | convert_options(R)];
+convert_options([{<<"src_rate_limit">>, V} | R]) ->
+    [{src_rate_limit, couch_util:to_integer(V)} | convert_options(R)];
+convert_options([{<<"src_rate_period">>, V} | R]) ->
+    [{src_rate_period, couch_util:to_integer(V)} | convert_options(R)];
+convert_options([{<<"target_rate_limit">>, V} | R]) ->
+    [{target_rate_limit, couch_util:to_integer(V)} | convert_options(R)];
+convert_options([{<<"target_rate_period">>, V} | R]) ->
+    [{target_rate_period, couch_util:to_integer(V)} | convert_options(R)];
 convert_options([_ | R]) -> % skip unknown option
     convert_options(R).
 


### PR DESCRIPTION
This PR is more of a design/feature discussion. I am currently manually testing and writing tests. However, I'd like opinions about it's usefulness and overall feedback on the algorithm/design.

Purpose: To rate limit replications against clusters that have rate limitations (error 429) and also prevent DOS attacks by posting too many replication docs. 

Usage:
For a replication request we add in 4 new replication options:

src_rate_limit
src_rate_period
target_rate_limit
target_rate_period

These define the maximum number of requests per interval,
i.e limit = 10, period = 5 would be a rate of 2 requests per second.

When the number of send_reqs exceed the rate, we force that worker to sleep proportionally to the overflow (more info on that below). This allows replication to taper off when there are too many incoming requests.

Design (Modified Token Bucket Algorithm):

1 ETS table handled by a gen_server started by our couch_replicator_supervisor. The ETS table's key is HOST, which is the hostname of the remote url, stripped of the username and password. Each entry contains:

requestCounter - number of requests for one PERIOD interval.
lastUpdateTimestamp - the last time the background process reset the requestCounter to 0.
pid - the background process that is wakes up every PERIOD interval to reset the requestCounter to 0
replications = number of total Replication Jobs for this host,
limit - max send_requests for this host
period - interval for send_requests.

1) When a replication starts, we check if limit or period is defined for the replication job. If not, we initialize things normally. If both are defined, then we either create or update an entry in the HOSTS table with the new limit and period. We make this step synchronous with a gen_server:call to avoid concurrency issues with our read+write. However, a person could still change the limit and period for a particular host in the middle of another replication. So Rep A would be at 10 req/s, and then Rep B could come in while Rep A is still running and change it to 5 req/s. I still need to think this through if we should allow this. Every entry should have an associated process that is constantly resetting the requestCounter to 0 every PERIOD.

2) Before each send_req, we check to see if there is a limit and period defined. If not, sleep time is 0. If so, we update the requestCounter for that Host. Then based on the requestCounter overflow we tell the worker process to sleep proportionally + a delay time. So for example, if your limit is 5 reqs per second , and the 6th request came in at 800ms, then the process would sleep 200 ms. If the 7th request came in at 900 ms, it would sleep 100ms + 400 ms for and wake up at 1.4 seconds. We are trying to simulate a consistent rate. Currently, I have no limit on the sleep time, so if a ton of requests came in, there could be processes that sleep for a very long time. Most likely, I'll just have a max sleep time when reached we cancel the replication. These steps are asynchronous because ets:update_counter is atomic. 

3) At the end of a db_close, we synchronously decrement the replications counter for a particular host. If the counter reaches 0, we remove the entry from the table because there are no more replications for that host.

Let me know if there are any concurrency flaws in logic above.  
