### PR TITLE
Add Exponential Backoff for 429 errors.

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -141,7 +141,7 @@ process_response({ibrowse_req_id, ReqId}, Worker, HttpDb, Params, Callback) ->
 process_response({ok, Code, Headers, Body}, Worker, HttpDb, Params, Callback) ->
     case list_to_integer(Code) of
     429 ->
-        maybe_retry(back_off, Worker, HttpDb, Params);
+        maybe_retry(backoff, Worker, HttpDb, Params);
     Ok when (Ok >= 200 andalso Ok < 300) ; (Ok >= 400 andalso Ok < 500) ->
         couch_stats:increment_counter([couch_replicator, responses, success]),
         EJson = case Body of
@@ -167,7 +167,7 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
     {ibrowse_async_headers, ReqId, Code, Headers} ->
         case list_to_integer(Code) of
         429 ->
-            maybe_retry(back_off, Worker,
+            maybe_retry(backoff, Worker,
                 HttpDb#httpdb{timeout = ?MAX_BACKOFF_WAIT}, Params);
         Ok when (Ok >= 200 andalso Ok < 300) ; (Ok >= 400 andalso Ok < 500) ->
             StreamDataFun = fun() ->

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -283,7 +283,8 @@ maybe_retry(Error, _Worker, #httpdb{retries = Retries, wait = Wait} = HttpDb,
     % backwards compatibility.
     ok = timer:sleep(erlang:min(Wait, ?MAX_WAIT)),
     Wait2 = erlang:min(Wait * 2, ?MAX_WAIT),
-    NewHttpDb = HttpDb#httpdb{retries = Retries - 1, wait = Wait2},
+    WaitR = random:uniform(Wait2),
+    NewHttpDb = HttpDb#httpdb{retries = Retries - 1, wait = WaitR},
     throw({retry, NewHttpDb, Params}).
 
 


### PR DESCRIPTION
When we encounter a 429, we retry with a different set of retries and
timeout. This will theoretically reduce client replication overload.
When 429s have stopped, it's possible that a 500 error could occur.
Then the retry mechanism should go back to the original way for
backwards compatibility.
