### PR TITLE
Address Connection: Closed In Headers

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -222,16 +222,12 @@ clean_mailbox(_ReqId, 0) ->
 clean_mailbox({ibrowse_req_id, ReqId}, Count) when Count > 0 ->
     case get(?STREAM_STATUS) of
         {streaming, Worker} ->
-            ibrowse:stream_next(ReqId),
-            receive
-                {ibrowse_async_response, ReqId, _} ->
-                    clean_mailbox({ibrowse_req_id, ReqId}, Count - 1);
-                {ibrowse_async_response_end, ReqId} ->
+            case is_process_alive(Worker) of
+                true ->
+                    discard_message(ReqId, Worker, Count);
+                false ->
                     put(?STREAM_STATUS, ended),
                     ok
-                after 30000 ->
-                    exit(Worker, {timeout, ibrowse_stream_cleanup}),
-                    exit({timeout, ibrowse_stream_cleanup})
             end;
         Status when Status == init; Status == ended ->
             receive
@@ -246,6 +242,20 @@ clean_mailbox({ibrowse_req_id, ReqId}, Count) when Count > 0 ->
     end;
 clean_mailbox(_, Count) when Count > 0 ->
     ok.
+
+
+discard_message(ReqId, Worker, Count) ->
+    ibrowse:stream_next(ReqId),
+    receive
+        {ibrowse_async_response, ReqId, _} ->
+            clean_mailbox({ibrowse_req_id, ReqId}, Count - 1);
+        {ibrowse_async_response_end, ReqId} ->
+            put(?STREAM_STATUS, ended),
+            ok
+    after 30000 ->
+        exit(Worker, {timeout, ibrowse_stream_cleanup}),
+        exit({timeout, ibrowse_stream_cleanup})
+    end.
 
 
 maybe_retry(Error, Worker, #httpdb{retries = 0} = HttpDb, Params) ->

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -128,7 +128,7 @@ process_response({error, connection_closing}, Worker, HttpDb, Params, _Cb) ->
     stop_and_release_worker(HttpDb#httpdb.httpc_pool, Worker),
     throw({retry, HttpDb, Params});
 
-process_response({error, {'EXIT',{normal,_}}}, _Worker, HttpDb, Params, _Cb) ->
+process_response({error, req_timedout}, _Worker, HttpDb, Params, _Cb) ->
     % ibrowse worker terminated because remote peer closed the socket
     % -> not an error
     throw({retry, HttpDb, Params});


### PR DESCRIPTION
This was encountered when testing replication with a proxy server that injected Connection:closed headers in a response. Two issues arise in our replicator when we see this in the header:

1) An older version of ibrowse would throw a {error, {'EXIT', normal}}, when a connection:closed header was received. In the newer version of ibrowse, it throws {error, req_timedout} instead. This leads to a maybe_retry function call because we do not have a clause that handles this error. Which inevitably leads to the replication process dying once it exhausts the retry limit. So we change
the process_response clause to address this bug. However, this also means we could end up trying forever for real timeouts. If there is a way to distinguish between a real timeout vs a closed:connection, I'm open for sugesstions.

2) We call ibrowse:stop on the worker and release it from the worker pool. But our clean_mailbox tries to clean the mailbox of this worker when it's already dead, leading to a timeout that crashes the replicator. So we check to ensure that the Worker is still alive before we call ibrowse:stream_next.