### PR TITLE
Replication manager's rep_start_pids now contains only {Tag, Pid} items

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -183,7 +183,7 @@ init(_) ->
         scan_pid = ScanPid,
         max_retries = retries_value(
             config:get("replicator", "max_replication_retry_count", "10")),
-        rep_start_pids = [Pid],
+        rep_start_pids = [{?REPLICATOR_DB, Pid}],
         live = Live,
         epoch = Epoch
     }}.

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -48,6 +48,7 @@
 -define(AVG_ERROR_DELAY_MSEC, 100).
 -define(MAX_ERROR_DELAY_MSEC, 60000).
 -define(OWNER, <<"owner">>).
+-define(REPLICATOR_DB, <<"_replicator">>).
 
 -define(DB_TO_SEQ, db_to_seq).
 -define(CTX, {user_ctx, #user_ctx{roles=[<<"_admin">>, <<"_replicator">>]}}).
@@ -175,8 +176,8 @@ init(_) ->
     Epoch = make_ref(),
     ScanPid = spawn_link(fun() -> scan_all_dbs(Server) end),
     % Automatically start node local changes feed loop
-    ensure_rep_db_exists(<<"_replicator">>),
-    Pid = start_changes_reader(<<"_replicator">>, 0, Epoch),
+    ensure_rep_db_exists(?REPLICATOR_DB),
+    Pid = start_changes_reader(?REPLICATOR_DB, 0, Epoch),
     {ok, #state{
         event_listener = start_event_listener(),
         scan_pid = ScanPid,
@@ -951,7 +952,7 @@ scan_all_dbs(Server) when is_pid(Server) ->
 	end, ok).
 
 is_replicator_db(DbName) ->
-    <<"_replicator">> =:= couch_db:dbname_suffix(DbName).
+    ?REPLICATOR_DB =:= couch_db:dbname_suffix(DbName).
 
 get_json_value(Key, Props) ->
     get_json_value(Key, Props, undefined).


### PR DESCRIPTION
Previously the local change feed was added to rep_start_pids as Pid only. So if
replication manager stopped and terminate/2 was called before that change
feed died, then

```
foreach(fun({_Tag, Pid}) -> ... end, [StartPids])
```

would crash with a function clause error.

Jira: COUCHDB-3082
