### PR TITLE
Fix replicator manager `stop` change feed callback

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -389,7 +389,7 @@ changes_reader_cb({change, Change, _}, _, {Server, DbName, Epoch}) ->
     end,
     {Server, DbName, Epoch};
 changes_reader_cb({stop, EndSeq}, _, {Server, DbName, Epoch}) ->
-    Msg = {rep_db_checkpoint, DbName, EndSeq},
+    Msg = {rep_db_checkpoint, DbName, EndSeq, Epoch},
     ok = gen_server:call(Server, Msg, infinity),
     {Server, DbName, Epoch};
 changes_reader_cb(_, _, Acc) ->

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -388,7 +388,7 @@ changes_reader_cb({change, Change, _}, _, {Server, DbName, Epoch}) ->
             ok
     end,
     {Server, DbName, Epoch};
-changes_reader_cb({stop, EndSeq, _Pending}, _, {Server, DbName, Epoch}) ->
+changes_reader_cb({stop, EndSeq}, _, {Server, DbName, Epoch}) ->
     Msg = {rep_db_checkpoint, DbName, EndSeq},
     ok = gen_server:call(Server, Msg, infinity),
     {Server, DbName, Epoch};


### PR DESCRIPTION
```
changes_reader_cb({stop, EndSeq, _Pending}, ...) ->
   ...
```

at one point used to handle changes from `fabric:changes`. It was later
optimized to use shard change feeds, but shard change feed callbacks don't get
pending info with the `stop` message.

As a result replicator manager would always rescan all the changes in a shard
on any new change.

For reference, where `couch_changes.erl` calls the callback:
 https://github.com/apache/couchdb-couch/blob/master/src/couch_changes.erl#L654

Jira: COUCHDB-3104
