### PR TITLE
Port HTTP 429 Commits

### DIFF
--- a/src/couch_replicator_api_wrap.hrl
+++ b/src/couch_replicator_api_wrap.hrl
@@ -24,7 +24,8 @@
     retries = 10,
     wait = 250,         % milliseconds
     httpc_pool = nil,
-    http_connections
+    http_connections,
+    backoff = 25
 }).
 
 -record(oauth, {

--- a/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator_changes_reader.erl
@@ -52,7 +52,10 @@ read_changes(Parent, StartSeq, Db, ChangesQueue, Options, Ts) ->
         throw:recurse ->
             LS = get(last_seq),
             read_changes(Parent, LS, Db, ChangesQueue, Options, Ts+1);
-        exit:{http_request_failed, _, _, _} = Error ->
+        throw:retry_no_limit ->
+            LS = get(last_seq),
+            read_changes(Parent, LS, Db, ChangesQueue, Options, Ts);
+        throw:{retry_limit, Error} ->
         couch_stats:increment_counter(
             [couch_replicator, changes_read_failures]
         ),

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -277,12 +277,12 @@ backoff(Worker, #httpdb{backoff = Backoff} = HttpDb, Params) ->
     NewBackoff = erlang:min(Backoff2, ?MAX_BACKOFF_WAIT),
     NewHttpDb = HttpDb#httpdb{backoff = NewBackoff},
     case Backoff2 of
-        W0 when W0 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
+        W0 when W0 > ?MAX_BACKOFF_WAIT ->
+            report_error(Worker, HttpDb, Params, {error,
+                "Long 429-induced Retry Time Out"});
+        W1 when W1 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
             log_retry_error(Params, HttpDb, Backoff2, "429 Retry"),
             throw({retry, NewHttpDb, Params});
-        W1 when W1 > ?MAX_BACKOFF_WAIT ->
-            report_error(Worker, HttpDb, Params, {error,
-                "429 Retry Timeout"});
         _ ->
             throw({retry, NewHttpDb, Params})
     end.

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -180,6 +180,9 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
                 Ret = Callback(Ok, Headers, StreamDataFun),
                 Ret
             catch
+                throw:{maybe_retry_req, connection_closed} ->
+                    maybe_retry({connection_closed, mid_stream},
+                        Worker, HttpDb, Params);
                 throw:{maybe_retry_req, Err} ->
                     maybe_retry(Err, Worker, HttpDb, Params)
             end;


### PR DESCRIPTION
These commits allow us to not crash when a server returns a HTTP 429 response during replication.