### PR TITLE
Let "error" replication document updates bypass the VDU function.

### DIFF
--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -53,6 +53,14 @@
         var isReplicator = (userCtx.roles.indexOf('_replicator') >= 0);
         var isAdmin = (userCtx.roles.indexOf('_admin') >= 0);
 
+        if (newDoc._replication_state === 'error') {
+            // Skip validation in case when we update the document with the
+            // failed state. In this case it might be malformed. However,
+            // replicator will not pay attention to failed documents so this
+            // is safe.
+            return;
+        }
+
         if (oldDoc && !newDoc._deleted && !isReplicator &&
             (oldDoc._replication_state === 'triggered')) {
             reportError('Only the replicator can edit replication documents ' +


### PR DESCRIPTION
This is necessary in the case where an software upgrade happens with
a more restrictive VDU function. Replicator db might end up having documents
which would not pass validation anymore, leading to a replicator manager
crash when it updates the document with an "error" state.

So in case of an "error" state allow malformed document so the user can
see the error.

COUCHDB-3199