### PR TITLE
Format gen_server state to remove plain passwords

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -564,7 +564,8 @@ terminate_cleanup(State) ->
 format_status(_Opt, [_PDict, State]) ->
     Rep = couch_replicator_utils:format_rep_record(State#rep_state.rep_details),
     [{data, [
-        {"State", ?from_record(rep_state, State, [
+        {"State", [{rep_details, Rep} | ?from_record(rep_state, State, [
+            session_id,
             start_seq,
             committed_seq,
             current_through_seq,
@@ -574,11 +575,10 @@ format_status(_Opt, [_PDict, State]) ->
             src_starttime,
             tgt_starttime,
             timer, % checkpoint timer
-            session_id,
             source_seq,
             use_checkpoints,
             checkpoint_interval])
-       ++ [{rep_details, Rep}]}]}].
+       ]}]}].
 
 do_last_checkpoint(#rep_state{seqs_in_progress = [],
     highest_seq_done = {_Ts, ?LOWEST_SEQ}} = State) ->
@@ -1025,6 +1025,15 @@ format_status_test() ->
     Rep = Rep0#rep{source = #httpdb{url = S}, target = #httpdb{url = T}},
     State = State0#rep_state{rep_details = Rep},
     ?assertEqual([{data, [{"State", [
+        {rep_details,[
+            {source,"https://user_foo:*****@account_bar1.cloudant.com/database_baz/"},
+            {target,"https://user_foo:*****@account_bar2.cloudant.com/baz_backup/"},
+            {id,id},
+            {db_name,db_name},
+            {doc_id,doc_id},
+            {view,view},
+            {options,options}]},
+        {session_id,session_id},
         {start_seq,start_seq},
         {committed_seq,committed_seq},
         {current_through_seq,current_through_seq},
@@ -1033,17 +1042,9 @@ format_status_test() ->
         {src_starttime,src_starttime},
         {tgt_starttime,tgt_starttime},
         {timer,timer},
-        {session_id,session_id},
         {source_seq,source_seq},
         {use_checkpoints,use_checkpoints},
-        {checkpoint_interval,checkpoint_interval},
-        {rep_details,[{id,id},
-            {options,options},
-            {view,view},
-            {doc_id,doc_id},
-            {db_name,db_name},
-            {source,"https://user_foo:*****@account_bar1.cloudant.com/database_baz/"},
-            {target,"https://user_foo:*****@account_bar2.cloudant.com/baz_backup/"}]}
+        {checkpoint_interval,checkpoint_interval}
     ]}]}], format_status(normal, [[], State])).
 
 -endif.

--- a/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator_httpc_pool.erl
@@ -155,9 +155,7 @@ format_status(_Opt, [_PDict, #state{url = Url, limit = Limit}]) ->
     [{data, [{"State", [
         {url, couch_util:url_strip_password(Url)},
         {limit, Limit}
-    ]}]}];
-format_status(_Opt, [_PDict, State]) ->
-    [{data, [{"State", State}]}].
+    ]}]}].
 
 monitor_client(Callers, Worker, {ClientPid, _}) ->
     [{Worker, erlang:monitor(process, ClientPid)} | Callers].

--- a/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator_httpc_pool.erl
@@ -20,7 +20,7 @@
 
 % gen_server API
 -export([init/1, handle_call/3, handle_info/2, handle_cast/2]).
--export([code_change/3, terminate/2]).
+-export([code_change/3, terminate/2, format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -151,6 +151,14 @@ terminate(_Reason, State) ->
     lists:foreach(fun ibrowse_http_client:stop/1, State#state.free),
     lists:foreach(fun ibrowse_http_client:stop/1, State#state.busy).
 
+format_status(_Opt, [_PDict, #state{url = Url, limit = Limit}]) ->
+    [{data, [{"State", [
+        {url, couch_util:url_strip_password(Url)},
+        {limit, Limit}
+    ]}]}];
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", State}]}].
+
 monitor_client(Callers, Worker, {ClientPid, _}) ->
     [{Worker, erlang:monitor(process, ClientPid)} | Callers].
 
@@ -190,3 +198,18 @@ release_worker_internal(Worker, State) ->
    false ->
         State#state{callers = NewCallers0}
    end.
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+format_status_test() ->
+    Url = "https://user_foo:top_secret@account_bar1.cloudant.com/database_baz/",
+    State0 = list_to_tuple([state | record_info(fields, state)]),
+    State = State0#state{url = Url},
+    ?assertEqual([{data, [{"State", [
+        {url, "https://user_foo:*****@account_bar1.cloudant.com/database_baz/"},
+        {limit, limit}
+    ]}]}], format_status(normal, [[], State])).
+
+-endif.

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -511,16 +511,15 @@ ejsort_array([V | R], Acc) ->
     ejsort_array(R, [ejsort(V) | Acc]).
 
 format_rep_record(#rep{} = Rep) ->
-    ?from_record(rep, Rep, [
-        id,
-        options,
-        view,
-        doc_id,
-        db_name
-    ])
-     ++ [
+    [
         {source, format_httpdb(Rep#rep.source)},
         {target, format_httpdb(Rep#rep.target)}
+            | ?from_record(rep, Rep, [
+                id,
+                db_name,
+                doc_id,
+                view,
+                options])
     ].
 
 format_httpdb(#httpdb{url = Url}) ->
@@ -539,13 +538,13 @@ format_rep_record_test() ->
     T = "https://user_foo:top_secret@account_bar2.cloudant.com/baz_backup/",
     Rep = Rep0#rep{source = #httpdb{url = S}, target = #httpdb{url = T}},
     ?assertEqual([
-                  {id,id},
-        {options,options},
-        {view,view},
-        {doc_id,doc_id},
-        {db_name,db_name},
         {source,"https://user_foo:*****@account_bar1.cloudant.com/database_baz/"},
-        {target,"https://user_foo:*****@account_bar2.cloudant.com/baz_backup/"}
+        {target,"https://user_foo:*****@account_bar2.cloudant.com/baz_backup/"},
+        {id,id},
+        {db_name,db_name},
+        {doc_id,doc_id},
+        {view,view},
+        {options,options}
     ], format_rep_record(Rep)).
 
 ejsort_basic_values_test() ->

--- a/test/couch_replicator_state_format_tests.erl
+++ b/test/couch_replicator_state_format_tests.erl
@@ -1,0 +1,228 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_replicator_state_format_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+%%-define(TIMEOUT_EUNIT, 30).
+-define(TIMEOUT, 1000).
+
+-define(USER, "user_foo").
+-define(PASS, "top_secret").
+
+setup() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db),
+    DbName.
+
+setup(local) ->
+    setup();
+setup(remote) ->
+    {remote, setup()};
+setup({Service, {A, B}}) ->
+    Ctx = test_util:start_couch([couch_replicator]),
+    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Source = setup(A),
+    Target = setup(B),
+    {ok, Pid} = start(Service, {Source, Target}),
+    {Ctx, Pid, {Source, Target}}.
+
+teardown({remote, DbName}) ->
+    teardown(DbName);
+teardown(DbName) ->
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]),
+    ok.
+
+teardown({_, _}, {Ctx, _Pid, {Source, Target}}) ->
+    teardown(Source),
+    teardown(Target),
+    %%exit(Pid, kill),
+    ok = test_util:stop_couch(Ctx).
+
+start(replicator, {Source, Target}) ->
+    RepObject = {[
+        {<<"source">>, db(Source)},
+        {<<"target">>, db(Target)},
+        {<<"use_checkpoints">>, false}
+    ]},
+    {ok, Rep} = couch_replicator_utils:parse_rep_doc(RepObject, ?ADMIN_USER),
+    {ok, Pid} = gen_server:start_link(couch_replicator, Rep, []),
+    {ok, Pid};
+start(worker, {Source, Target}) ->
+    {ok, Pid} = couch_replicator_worker:start_link(
+        self(), db(Source), db(Target), self(), 1),
+    receive
+        {get_changes, _} ->
+            ok
+    after ?TIMEOUT ->
+            throw(timeout)
+    end,
+    {ok, Pid};
+start(httpc_pool, {Source, _Target}) ->
+    couch_replicator_httpc_pool:start_link(db(Source), []);
+start(manager, {_Source, _Target}) ->
+    {ok, whereis(couch_replicator_manager)}.
+
+
+state_format_test_() ->
+    Pairs = [{local, local}, {local, remote},
+             {remote, local}, {remote, remote}],
+    Tests = [
+        fun should_format_state/2,
+        fun should_strip_credentials/2
+    ],
+    Targets = [replicator, worker, httpc_pool, manager],
+    {
+        "Make sure we format state of the process",
+        {
+            foreachx,
+            fun setup/1, fun teardown/2,
+            [{{Target, Pair}, Test}
+                ||
+                    Pair <- Pairs,
+                    Test <- Tests,
+                    Target <- Targets]
+        }
+    }.
+
+should_format_state({replicator, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        ExpectedStateKeys = [
+            start_seq,
+            committed_seq,
+            current_through_seq,
+            highest_seq_done,
+            rep_starttime,
+            src_starttime,
+            tgt_starttime,
+            timer,
+            session_id,
+            source_seq,
+            use_checkpoints,
+            checkpoint_interval,
+            rep_details
+        ],
+        ?assertEqualLists(ExpectedStateKeys, proplists:get_keys(State)),
+        RepState = proplists:get_value(rep_details, State),
+        ExpectedRepKeys = [
+            id,
+            options,
+            view,
+            doc_id,
+            db_name,
+            source,
+            target
+        ],
+        ?assertEqualLists(ExpectedRepKeys, proplists:get_keys(RepState)),
+        ok
+    end)};
+should_format_state({worker, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        ExpectedStateKeys = [
+            cp,
+            loop,
+            max_parallel_conns,
+            writer,
+            pending_fetch,
+            flush_waiter,
+            source_db_compaction_notifier,
+            target_db_compaction_notifier,
+            batch,
+            source,
+            target
+        ],
+        ?assertEqualLists(ExpectedStateKeys, proplists:get_keys(State)),
+        ok
+    end)};
+should_format_state({httpc_pool, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        ExpectedStateKeys = [
+            url,
+            limit
+        ],
+        ?assertEqualLists(ExpectedStateKeys, proplists:get_keys(State)),
+        ok
+    end)};
+should_format_state({manager, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        ExpectedStateKeys = [
+            event_listener,
+            scan_pid,
+            max_retries,
+            epoch
+        ],
+        ?assertEqualLists(ExpectedStateKeys, proplists:get_keys(State)),
+        ok
+    end)}.
+
+
+should_strip_credentials({replicator, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        RepState = proplists:get_value(rep_details, State),
+        Source = proplists:get_value(source, RepState),
+        Target = proplists:get_value(target, RepState),
+        ?assertNot(contains_password(Source)),
+        ?assertNot(contains_password(Target)),
+        ok
+    end)};
+should_strip_credentials({worker, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        Source = proplists:get_value(source, State),
+        Target = proplists:get_value(target, State),
+        ?assertNot(contains_password(Source)),
+        ?assertNot(contains_password(Target)),
+        ok
+    end)};
+should_strip_credentials({httpc_pool, _} = Args, {_Ctx, Pid, _}) ->
+    {test_id(Args), ?_test(begin
+        State = get_state(Pid),
+        URL = proplists:get_value(url, State),
+        ?assertNot(contains_password(URL)),
+        ok
+    end)};
+should_strip_credentials({manager, _} = Args, {_Ctx, _Pid, _}) ->
+    {test_id(Args), ?_test(ok)}.
+
+test_id({Target, {From, To}}) ->
+    lists:flatten(io_lib:format("~p: ~p -> ~p", [Target, From, To])).
+
+db({remote, DbName}) ->
+    iolist_to_binary([
+        "http://", ?USER, ":", ?PASS, "@",
+        config:get("httpd", "bind_address", "127.0.0.1"),
+        ":", integer_to_list(mochiweb_socket_server:get(couch_httpd, port)),
+        "/", DbName
+    ]);
+db(DbName) ->
+    DbName.
+
+contains_password(Bin) when is_binary(Bin) ->
+    contains_password(?b2l(Bin));
+contains_password(String) ->
+    string:str(String, ?PASS) =/= 0.
+
+get_state(Pid) ->
+    {status, Pid, {module, _}, SItems} = sys:get_status(Pid),
+    Filtered = [Props || Props <- SItems, is_list(Props)],
+    Misc = lists:flatten(lists:foldl(fun(SItem, _) ->
+        proplists:get_all_values(data, SItem)
+    end, undefined, Filtered)),
+    proplists:get_value("State", Misc).


### PR DESCRIPTION
Add format_status/2 to every gen_server to prune the state before
passing it to SASL logger. There are two goals for this work:
- eliminate plain text passwords in the logs
- reduce the size of the terms we log

The size of a term is a real problem. Since what's currently happening is:
1. we have lot's of data in state (queues for example)
2. the process crashes so the term is send to group leader
3. eventually lagger receives the term
4. couch_log format the term (we have io:format fork [couch_log_trunc_io_fmt](https://github.com/apache/couchdb-couch-log/blob/master/src/couch_log_trunc_io_fmt.erl))

Having truncate in step `#4` doesn't help much in case we have lot's of events to log. Since we bottleneck on group leader mailbox. Therefore we need to reduce the term size before we attempt to log it. 

COUCHDB-1606
