### PR TITLE
Switch replicator max_document_id_length config to use infinity

### DIFF
--- a/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator_changes_reader.erl
@@ -123,5 +123,10 @@ process_change({last_seq, _}, _) ->
     ok.
 
 is_doc_id_too_long(IdLength) ->
-    ConfigMax = config:get_integer("replicator", "max_document_id_length", 0),
-    ConfigMax > 0 andalso IdLength > ConfigMax.
+    case config:get("replicator", "max_document_id_length", "infinity") of
+        "infinity" ->
+            false;
+        ConfigMaxStr ->
+            ConfigMax = list_to_integer(ConfigMaxStr),
+            ConfigMax > 0 andalso IdLength > ConfigMax
+    end.

--- a/test/couch_replicator_id_too_long_tests.erl
+++ b/test/couch_replicator_id_too_long_tests.erl
@@ -28,7 +28,7 @@ setup(_) ->
 teardown(_, {Ctx, {Source, Target}}) ->
     delete_db(Source),
     delete_db(Target),
-    config:set("replicator", "max_document_id_length", "0"),
+    config:set("replicator", "max_document_id_length", "infinity"),
     ok = test_util:stop_couch(Ctx).
 
 


### PR DESCRIPTION
Default value switched to be `infinity` instead of 0

COUCHDB-3291